### PR TITLE
[video streaming] Added initial ImageZMQ client and server files

### DIFF
--- a/controller/main_module.py
+++ b/controller/main_module.py
@@ -2,13 +2,9 @@
 import cv2
 import imagezmq
 image_hub = imagezmq.ImageHub()
-#print("got here 1")
 while True:  # show streamed images until Ctrl-C
-    #print("got here 2")
     rpi_name, image = image_hub.recv_image()
     cv2.namedWindow(rpi_name, cv2.WINDOW_AUTOSIZE)
     cv2.imshow(rpi_name, image)  # 1 window for each RPi
     cv2.waitKey(1)
     image_hub.send_reply(b'OK')
-    # if cv2.waitKey(1) & 0xFF == ord('q'):
-    #    break

--- a/controller/main_module.py
+++ b/controller/main_module.py
@@ -1,0 +1,14 @@
+# run this program on the Mac to display image streams from multiple RPis
+import cv2
+import imagezmq
+image_hub = imagezmq.ImageHub()
+#print("got here 1")
+while True:  # show streamed images until Ctrl-C
+    #print("got here 2")
+    rpi_name, image = image_hub.recv_image()
+    cv2.namedWindow(rpi_name, cv2.WINDOW_AUTOSIZE)
+    cv2.imshow(rpi_name, image)  # 1 window for each RPi
+    cv2.waitKey(1)
+    image_hub.send_reply(b'OK')
+    # if cv2.waitKey(1) & 0xFF == ord('q'):
+    #    break

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -13,7 +13,7 @@ args = vars(ap.parse_args())
 
 sender = imagezmq.ImageSender(connect_to="tcp://{}:5555".format(
     args["server_ip"]))
-#sender = imagezmq.ImageSender(connect_to='tcp://jeff-macbook:5555')
+
 
 rpi_name = socket.gethostname()  # send RPi hostname with each image
 picam = VideoStream(src=0).start()

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -5,7 +5,6 @@ from imutils.video import VideoStream
 import imagezmq
 import argparse
 
-#print("got here")
 ap = argparse.ArgumentParser()
 ap.add_argument("-s", "--server-ip", required=True,
                 help="ip address of the server to which the client will connect")
@@ -22,5 +21,3 @@ time.sleep(2.0)  # allow camera sensor to warm up
 while True:  # send images as stream until Ctrl-C
     image = picam.read()
     sender.send_image(rpi_name, image)
-    # if cv2.waitKey(1) & 0xFF == ord('q'):
-    #    break

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -1,0 +1,26 @@
+# run this program on each RPi to send a labelled image stream
+import socket
+import time
+from imutils.video import VideoStream
+import imagezmq
+import argparse
+
+#print("got here")
+ap = argparse.ArgumentParser()
+ap.add_argument("-s", "--server-ip", required=True,
+                help="ip address of the server to which the client will connect")
+args = vars(ap.parse_args())
+
+sender = imagezmq.ImageSender(connect_to="tcp://{}:5555".format(
+    args["server_ip"]))
+#sender = imagezmq.ImageSender(connect_to='tcp://jeff-macbook:5555')
+
+rpi_name = socket.gethostname()  # send RPi hostname with each image
+picam = VideoStream(src=0).start()
+time.sleep(2.0)  # allow camera sensor to warm up
+
+while True:  # send images as stream until Ctrl-C
+    image = picam.read()
+    sender.send_image(rpi_name, image)
+    # if cv2.waitKey(1) & 0xFF == ord('q'):
+    #    break


### PR DESCRIPTION
### Summary
Included in this pull request are 2 files, one main_module in the wallu/vision folder that handles streaming video to another computer at the specified IP, and one main_module in the controller folder handles receiving the video and presenting it to the remote user.

### Test Plan
- I tested running these programs locally on my own machine, and that succeeded.
- I then tested streaming from one computer to another on a local network, and that succeeded.
- The second test had minimal latency.
- I still need to test running these scripts on the Rasperry Pi Zero WH's.

### Notes: 
- Make sure to have openCV, imageZMQ, and imutils installed to run either of the programs.
- The script for receiving the stream must be run before the script for transmitting the stream.