### PR TITLE
[mqtt] Changed handshake from P2P to Alpha/Beta system

### DIFF
--- a/comms/mqtt/interface.py
+++ b/comms/mqtt/interface.py
@@ -60,6 +60,7 @@ class MqttInterface:
         if self.alpha:
             self.subscribe("pulse")
         else:
+            self.subscribe("runtime_config")
             pulse_thread = threading.Thread(target=self.pulse_forever)
             pulse_thread.start()
 

--- a/comms/mqtt/interface.py
+++ b/comms/mqtt/interface.py
@@ -4,10 +4,14 @@ To start broker, run:
 '''
 
 import paho.mqtt.client as mqtt
+import threading
+import time
 
 TOPIC_PREFIX = "ece180d/team3/wallu/"
 MQTT_QOS = 1
+PULSE_PERIOD = 250
 
+millis = lambda: int(round(time.time() * 1000))
 
 def on_disconnect(client, userdata, rc):
     # Disconnect callback
@@ -24,16 +28,16 @@ def default_callback(client, userdata, message):
 
 
 class MqttInterface:
-    def __init__(self, id, targets, topics, callback=0):
+    def __init__(self, id, targets, topics, callback=0, alpha=False):
         self.id = id
         self.mqtt_client = mqtt.Client()
         self.mqtt_client.on_connect = self.on_connect
         self.mqtt_client.on_disconnect = on_disconnect
-
         self.targets = targets
+        self.alpha = alpha
+        self.last_pulse = 0
+
         self.topics = topics
-        self.subscribed_topics = []
-        self.connected_targets = []
         self.pulses = {}
 
         if callback == 0:
@@ -50,18 +54,18 @@ class MqttInterface:
 
         print("Connected to MQTT broker.")
 
-        for target in self.targets:
-            target_topic = "pulse_" + str(target)
-            self.subscribe(target_topic)
-
         for topic in self.topics:
             self.subscribe(topic)
-            
+
+        if self.alpha:
+            self.subscribe("pulse")
+        else:
+            pulse_thread = threading.Thread(target=self.pulse_forever)
+            pulse_thread.start()
 
     def subscribe(self, topic):
         full_topic = TOPIC_PREFIX + str(topic)
         self.mqtt_client.subscribe(full_topic, qos=MQTT_QOS)
-        self.subscribed_topics.append(topic)
 
     def set_callback(self, callback):
         self.mqtt_client.on_message = callback
@@ -77,23 +81,20 @@ class MqttInterface:
         self.mqtt_client.loop_stop()
         self.mqtt_client.disconnect()
 
-    def pulse_check(self, topic, payload):
-        pulse_split = topic.split("pulse_")
-        if len(pulse_split) == 2:
-            # Received pulse
-            target = pulse_split[1]
-            if payload == "init" and not target in self.pulses:
-                self.pulses[target] = "init"
+    def register_pulse(self, target):
+        if target in self.targets:
+            self.pulses[target] = millis()
+            print("Registered pulse from: " + target)
+        else:
+            print("Received pulse from unrecognized target: " + target)
 
-    def handshake(self, target):
+    def target_check(self, target):
+        return (target in self.pulses) and (millis() - self.pulses[target] < 1.5*PULSE_PERIOD)
+
+    def pulse_forever(self):
         # Send init message
-        self.send_message("pulse_" + self.id, "init")
-
-        # Make sure not already connected to target
-        if target in self.connected_targets:
-            return True
-
-        if target in self.pulses and self.pulses[target] == "init":
-            print("Connected to " + str(target))
-            self.connected_targets.append(target)
-
+        while True:
+            time_elapsed = millis() - self.last_pulse
+            if  time_elapsed >= PULSE_PERIOD:
+                self.send_message("pulse", self.id)
+                self.last_pulse = millis()

--- a/controller/main_module.py
+++ b/controller/main_module.py
@@ -116,8 +116,11 @@ while True:
     if not all(mqtt_manager.target_check(target) for target in mqtt_targets):
         # not ready for normal operation
         print("Waiting for all devices to come online...")
+        mqtt_manager.send_message("runtime_config", "0")
         time.sleep(0.5)
         continue
+    else:
+        mqtt_manager.send_message("runtime_config", "1")
 
     rpi_name, jpg_buffer = image_hub.recv_jpg()
     image = cv2.imdecode(np.frombuffer(jpg_buffer, dtype='uint8'), -1)

--- a/controller/main_module.py
+++ b/controller/main_module.py
@@ -16,6 +16,7 @@ import subprocess
 import select
 
 kUnlockTimer = 20
+millis = lambda: int(round(time.time() * 1000))
 
 class Coord:
     def __init__(self, y, x):
@@ -59,15 +60,17 @@ def add_text_overlays(image, hud):
 
 def mqtt_callback(client, userdata, message):
     payload = message.payload
-    topic = message.topic
     decoded_payload = ""
     try:
         decoded_payload = payload.decode("utf-8")
     except:
         pass
-    mqtt_manager.pulse_check(topic, decoded_payload)
 
-    parsed_topic = topic.split('/')[-1]
+    parsed_topic = message.topic.split('/')[-1]
+
+    if parsed_topic == "pulse":
+        mqtt_manager.register_pulse(decoded_payload)
+
     if parsed_topic == "motor_requests":
         motor_request = motor_requests_pb2.MotorRequest()
         motor_request.ParseFromString(payload)
@@ -101,30 +104,21 @@ hud_data = HudData()
 mqtt_id = "laptop"
 mqtt_targets = ["vision", "wallu", "wheel"]
 mqtt_topics = ["motor_requests", "storage_control", "vitals"]
-mqtt_manager = mqtt_interface.MqttInterface(id=mqtt_id, targets=mqtt_targets, topics=mqtt_topics, callback=mqtt_callback)
+mqtt_manager = mqtt_interface.MqttInterface(id=mqtt_id, targets=mqtt_targets, topics=mqtt_topics, callback=mqtt_callback, alpha=True)
 mqtt_manager.start_reading()
-
-# First connect to Wheel Main Pi
-print("Opening connection to Steering Wheel Main...")
-while not mqtt_manager.handshake("wheel"):
-    time.sleep(0.5)
-
-# Then connect to WALL-U Main Pi
-print("Opening connection to WALL-U Main...")
-while not mqtt_manager.handshake("wallu"):
-    time.sleep(0.5)
 
 #thread = threading.Thread(target=voice_unlock.start_listening, args=("unlock", voice_callback))
 #thread.start()
 
-# Then connect to WALL-U Vision Pi
-print("Opening connection to WALL-U Vision...")
-while not mqtt_manager.handshake("vision"):
-    time.sleep(0.5)
-
-
 image_hub = imagezmq.ImageHub()
 while True:
+
+    if not all(mqtt_manager.target_check(target) for target in mqtt_targets):
+        # not ready for normal operation
+        print("Waiting for all devices to come online...")
+        time.sleep(0.5)
+        continue
+
     rpi_name, jpg_buffer = image_hub.recv_jpg()
     image = cv2.imdecode(np.frombuffer(jpg_buffer, dtype='uint8'), -1)
     image = cv2.resize(image, (1920,1080))

--- a/controller/wheel/main_module.py
+++ b/controller/wheel/main_module.py
@@ -17,8 +17,10 @@ def mqtt_callback(client, userdata, message):
     parsed_topic = message.topic.split('/')[-1]
     if parsed_topic == "runtime_config":
         try:
-            runtime_config = int(payload.decode("utf-8"))
-            print("Set runtime config to " + str(runtime_config))
+            new_config = int(payload.decode("utf-8"))
+            if new_config != runtime_config:
+                runtime_config = new_config
+                print("Set runtime config to " + str(runtime_config))
         except:
             print("Could not parse runtime config, resetting to standby.")
             runtime_config = 0

--- a/controller/wheel/main_module.py
+++ b/controller/wheel/main_module.py
@@ -10,7 +10,8 @@ import threading
 import time
 
 def mqtt_callback(client, userdata, message):
-    # Print all messages
+    global runtime_config
+
     payload = message.payload
     topic = message.topic
 
@@ -50,8 +51,8 @@ mqtt_id = "wheel"
 mqtt_targets = ["laptop"]
 mqtt_topics = []
 mqtt_manager = mqtt_interface.MqttInterface(id=mqtt_id, targets=mqtt_targets, topics=mqtt_topics, callback=mqtt_callback)
-mqtt_manager.start_reading()
 runtime_config = 0
+mqtt_manager.start_reading()
 
 # First connect to Controller Main
 while runtime_config == 0:

--- a/wallu/main_module.py
+++ b/wallu/main_module.py
@@ -60,6 +60,15 @@ def mqtt_callback(client, userdata, message):
     mqtt_manager.pulse_check(topic, decoded_payload)
 
     parsed_topic = topic.split('/')[-1]
+
+    if parsed_topic == "runtime_config":
+        try:
+            runtime_config = int(decoded_payload)
+            print("Set runtime config to " + str(runtime_config))
+        except:
+            print("Could not parse runtime config, resetting to standby.")
+            runtime_config = 0
+
     if parsed_topic == "motor_requests":
         motor_request = motor_requests_pb2.MotorRequest()
         motor_request.ParseFromString(payload)
@@ -101,9 +110,11 @@ mqtt_targets = ["laptop"]
 mqtt_topics = ["motor_requests", "storage_control"]
 mqtt_manager = mqtt_interface.MqttInterface(id=mqtt_id, targets=mqtt_targets, topics=mqtt_topics, callback=mqtt_callback)
 mqtt_manager.start_reading()
+runtime_config = 0
 
-print("Opening connection to Controller Main...")
-while not mqtt_manager.handshake("laptop"):
+# First connect to Controller Main
+while runtime_config == 0:
+    print("Waiting for instructions from main controller...")
     time.sleep(0.5)
 
 while True:

--- a/wallu/main_module.py
+++ b/wallu/main_module.py
@@ -62,8 +62,10 @@ def mqtt_callback(client, userdata, message):
 
     if parsed_topic == "runtime_config":
         try:
-            runtime_config = int(decoded_payload)
-            print("Set runtime config to " + str(runtime_config))
+            new_config = int(payload.decode("utf-8"))
+            if new_config != runtime_config:
+                runtime_config = new_config
+                print("Set runtime config to " + str(runtime_config))
         except:
             print("Could not parse runtime config, resetting to standby.")
             runtime_config = 0

--- a/wallu/main_module.py
+++ b/wallu/main_module.py
@@ -57,7 +57,6 @@ def mqtt_callback(client, userdata, message):
         decoded_payload = payload.decode("utf-8")
     except:
         pass
-    mqtt_manager.pulse_check(topic, decoded_payload)
 
     parsed_topic = topic.split('/')[-1]
 

--- a/wallu/main_module.py
+++ b/wallu/main_module.py
@@ -49,7 +49,8 @@ def write_motor_request(request):
     serial_interface.write_to_port(req)
 
 def mqtt_callback(client, userdata, message):
-    # Print all messages
+    global runtime_config
+    
     payload = message.payload
     topic = message.topic
     decoded_payload = ""
@@ -110,8 +111,8 @@ mqtt_id = "wallu"
 mqtt_targets = ["laptop"]
 mqtt_topics = ["motor_requests", "storage_control"]
 mqtt_manager = mqtt_interface.MqttInterface(id=mqtt_id, targets=mqtt_targets, topics=mqtt_topics, callback=mqtt_callback)
-mqtt_manager.start_reading()
 runtime_config = 0
+mqtt_manager.start_reading()
 
 # First connect to Controller Main
 while runtime_config == 0:

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -24,8 +24,10 @@ def mqtt_callback(client, userdata, message):
     parsed_topic = message.topic.split('/')[-1]
     if parsed_topic == "runtime_config":
         try:
-            runtime_config = int(payload.decode("utf-8"))
-            print("Set runtime config to " + str(runtime_config))
+            new_config = int(payload.decode("utf-8"))
+            if new_config != runtime_config:
+                runtime_config = new_config
+                print("Set runtime config to " + str(runtime_config))
         except:
             print("Could not parse runtime config, resetting to standby.")
             runtime_config = 0

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -17,7 +17,8 @@ sender = imagezmq.ImageSender(connect_to="tcp://{}:5555".format(
     SERVER_IP))
 
 def mqtt_callback(client, userdata, message):
-    # Print all messages
+    global runtime_config
+    
     payload = message.payload.decode("utf-8")
     topic = message.topic
 
@@ -37,6 +38,7 @@ mqtt_id = "vision"
 mqtt_targets = ["laptop"]
 mqtt_topics = []
 mqtt_manager = mqtt_interface.MqttInterface(id=mqtt_id, targets=mqtt_targets, topics=mqtt_topics, callback=mqtt_callback)
+runtime_config = 0
 mqtt_manager.start_reading()
 
 # First connect to Controller Main

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -20,7 +20,6 @@ def mqtt_callback(client, userdata, message):
     # Print all messages
     payload = message.payload.decode("utf-8")
     topic = message.topic
-    mqtt_manager.pulse_check(topic, payload)
 
     parsed_topic = message.topic.split('/')[-1]
     if parsed_topic == "runtime_config":

--- a/wallu/vision/main_module.py
+++ b/wallu/vision/main_module.py
@@ -25,7 +25,7 @@ def mqtt_callback(client, userdata, message):
     parsed_topic = message.topic.split('/')[-1]
     if parsed_topic == "runtime_config":
         try:
-            new_config = int(payload.decode("utf-8"))
+            new_config = int(payload)
             if new_config != runtime_config:
                 runtime_config = new_config
                 print("Set runtime config to " + str(runtime_config))


### PR DESCRIPTION
### Summary
In order to move to an implementation that is more hierarchical, I changed the handshake scheme from a peer-to-peer model to a more central model, where devices are either "Alpha" or "Beta". Alpha devices can send out commands, while Beta devices send periodic pulses and respond to commands from Alpha. Beta devices can obviously still send sensor data.

This PR also adds the groundwork for enabling different runtime configurations. Currently, the following are defined:
- 0: Standby. Devices continue to send pulses, but do not resume normal operation
- 1: Storage control. This is the mode that we developed last quarter.

### Test Plan
This PR has been tested with all modules except the steering wheel. Should be good to go.